### PR TITLE
Only deploy when a tag exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ deploy:
   file: "$TRAVIS_OS_NAME.tar.gz"
   on:
     condition: $DEPLOY_GITHUB_RELEASE = true
+    tags: true
   skip_cleanup: true
 
 # EOF


### PR DESCRIPTION
We only want specific versions of binaries released.
Without this check, every commit to master would create a release.